### PR TITLE
fix(dependency): use font-awesome from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "bootstrap": "4.0.0-alpha.6",
     "classlist.js": "^1.1",
     "core-js": "^2.4.1",
+    "font-awesome": "^4.7.0",
     "hammerjs": "^2.0.8",
     "rxjs": "^5.4.2",
     "uuid": "^3.1.0",

--- a/src/index.html
+++ b/src/index.html
@@ -13,7 +13,6 @@
 
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-  <script src="https://use.fontawesome.com/2fcf1416f4.js"></script>
   <style type="text/css">
     body, html {
       height: 100%;

--- a/src/styles-variables.scss
+++ b/src/styles-variables.scss
@@ -1,3 +1,5 @@
 $toolbar-breakpoint: 600px;
 
+$fa-font-path: '~font-awesome/fonts';
+
 $grid-breakpoints: (xs: 0, sm: 576px, md: 768px, lg: 992px, xl: 1200px);

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -4,6 +4,8 @@
 @import '~bootstrap/scss/bootstrap-grid';
 @import '~bootstrap/scss/utilities';
 
+@import '~font-awesome/scss/font-awesome';
+
 @import 'styles-reset';
 
 @import '~@angular/material/theming';


### PR DESCRIPTION
Fix 404 error when trying to load some font files of Font Awesome from CDN.
Used NPM version instead.