### PR TITLE
Fix E2E Tests

### DIFF
--- a/e2e/app.e2e-spec.ts
+++ b/e2e/app.e2e-spec.ts
@@ -9,6 +9,6 @@ describe('angular-ngrx-material-starter App', () => {
 
   it('should display message saying app works', () => {
     page.navigateTo();
-    expect(page.getParagraphText()).toEqual('app works!');
+    expect(page.getParagraphText()).toEqual('ANGULAR NGRX MATERIAL STARTER');
   });
 });

--- a/e2e/app.po.ts
+++ b/e2e/app.po.ts
@@ -6,6 +6,6 @@ export class AngularNgrxMaterialStarterPage {
   }
 
   getParagraphText() {
-    return element(by.css('app-root h1')).getText();
+    return element(by.css('anms-root h1')).getText();
   }
 }


### PR DESCRIPTION
Currently, when you clone from master and run `ng e2e` you get the error:  `Failed: No element found using locator: By(css selector, app-root h1)`. 

This simple PR just fixes the e2e test to find the correct element and expect a different value of text.