### PR TITLE
fix(app): track pageviews in Google Analytics

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -101,19 +101,22 @@ export class AppComponent implements OnInit, OnDestroy {
 
   private subscribeToRouterEvents() {
     this.router.events
-    .pipe(
-      takeUntil(this.unsubscribe$),
-      filter(event => event instanceof ActivationEnd || event instanceof NavigationEnd)
-    )
-    .subscribe((event: ActivationEnd) => {
-      if (event instanceof ActivationEnd) {
-        this.setPageTitle(event);
-      }
+      .pipe(
+        takeUntil(this.unsubscribe$),
+        filter(
+          event =>
+            event instanceof ActivationEnd || event instanceof NavigationEnd
+        )
+      )
+      .subscribe((event) => {
+        if (event instanceof ActivationEnd) {
+          this.setPageTitle(event);
+        }
 
-      if (event instanceof NavigationEnd) {
-        this.trackPageView(event);
-      }
-    });
+        if (event instanceof NavigationEnd) {
+          this.trackPageView(event);
+        }
+      });
   }
 
   private setPageTitle(event: ActivationEnd) {

--- a/src/index.html
+++ b/src/index.html
@@ -85,7 +85,6 @@
     })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
     ga('create', 'UA-53234284-5', 'auto');
-    ga('send', 'pageview');
   </script>
 </body>
 </html>


### PR DESCRIPTION
In order to track each view as a 'pageview' in Google Analytics, we need to subscribe to the router `NavigationEnd` event and manually set the pageview for each application view.

#173