### PR TITLE
test(stock-market-component): create unit tests for stock-market comp…

### DIFF
--- a/src/app/examples/stock-market/stock-market.component.spec.ts
+++ b/src/app/examples/stock-market/stock-market.component.spec.ts
@@ -1,31 +1,178 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  async,
+  ComponentFixture,
+  inject,
+  TestBed
+} from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { HttpErrorResponse } from '@angular/common/http';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { RouterTestingModule } from '@angular/router/testing';
 
+import { Store } from '@ngrx/store';
+import { TestingModule, TestStore } from '@testing/utils';
 import { CoreModule } from '@app/core';
-import { TestingModule } from '@testing/utils';
 
 import { ExamplesModule } from '../examples.module';
 
 import { StockMarketComponent } from './stock-market.component';
+import {
+  StockMarketState,
+  ActionStockMarketRetrieve
+} from './stock-market.reducer';
 
 describe('StockMarketComponent', () => {
   let component: StockMarketComponent;
   let fixture: ComponentFixture<StockMarketComponent>;
+  let store: TestStore<StockMarketState>;
 
-  beforeEach(
-    async(() => {
-      TestBed.configureTestingModule({
-        imports: [TestingModule, CoreModule, ExamplesModule]
-      }).compileComponents();
-    })
-  );
+  const getSpinner = () => fixture.debugElement.query(By.css('mat-spinner'));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(StockMarketComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+  const getError = () => fixture.debugElement.query(By.css('.error'));
 
-  it('should be created', () => {
-    expect(component).toBeTruthy();
+  const getStocks = () =>
+    fixture.debugElement.query(By.css('mat-card mat-card-title'));
+
+  const getInput = () => fixture.debugElement.query(By.css('input'));
+
+  const getExchange = () =>
+    fixture.debugElement.query(By.css('mat-card mat-card-content'));
+
+  const getChange = () =>
+    fixture.debugElement.query(By.css('mat-card mat-card-subtitle'));
+
+  const getCaretUpDownItem = () =>
+    fixture.debugElement.query(
+      By.css('mat-card mat-icon[fontIcon="fa-caret-down"]')
+    );
+
+  describe('given component booted', () => {
+    beforeEach(
+      async(() => {
+        TestBed.configureTestingModule({
+          imports: [TestingModule, CoreModule, ExamplesModule],
+          providers: [{ provide: Store, useClass: TestStore }]
+        }).compileComponents();
+      })
+    );
+
+    beforeEach(
+      inject([Store], (testStore: TestStore<StockMarketState>) => {
+        store = testStore;
+        store.setState({ symbol: '', loading: true });
+        fixture = TestBed.createComponent(StockMarketComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+      })
+    );
+
+    it('should be created', () => {
+      expect(component).toBeTruthy();
+    });
+
+    describe('and input changed', () => {
+      let dispatchSpy: jasmine.Spy;
+
+      beforeEach(() => {
+        dispatchSpy = spyOn(store, 'dispatch');
+        getInput().triggerEventHandler('keyup', { target: { value: 'A' } });
+        fixture.detectChanges();
+      });
+
+      it('should trigger dispatch with correct input', () => {
+        expect(dispatchSpy).toHaveBeenCalledTimes(1);
+        expect(dispatchSpy).toHaveBeenCalledWith(
+          new ActionStockMarketRetrieve({ symbol: 'A' })
+        );
+        expect(true).toBeTruthy();
+      });
+    });
+
+    describe('and stocks are loading', () => {
+      beforeEach(() => {
+        store.setState({ symbol: 'TDD', loading: true });
+        fixture.detectChanges();
+      });
+
+      it('should show spinner', () => {
+        expect(getSpinner()).toBeTruthy();
+      });
+    });
+
+    describe('and stocks are not loading', () => {
+      beforeEach(() => {
+        store.setState({ symbol: 'TDD', loading: false });
+        fixture.detectChanges();
+      });
+
+      it('should not show spinner', () => {
+        expect(getSpinner()).toBeFalsy();
+      });
+    });
+
+    describe('and the error happened on stock retrieval', () => {
+      beforeEach(() => {
+        store.setState({
+          symbol: 'TDD',
+          loading: false,
+          error: new HttpErrorResponse({})
+        });
+        fixture.detectChanges();
+      });
+
+      it('should show error', () => {
+        expect(getError()).toBeTruthy();
+      });
+    });
+
+    describe('and stock details are loaded', () => {
+      const symbol = 'TDD';
+      const exchange = 'TESTAQ';
+      const last = '123';
+      const ccy = 'USD';
+      const change = '100';
+      const changePercent = '11';
+
+      beforeEach(() => {
+        store.setState({
+          symbol,
+          loading: false,
+          stock: {
+            symbol,
+            exchange,
+            last,
+            ccy,
+            change,
+            changePercent,
+            changeNegative: true,
+            changePositive: false
+          }
+        });
+
+        fixture.detectChanges();
+      });
+
+      it('should display the relevant caret item', () => {
+        expect(getCaretUpDownItem()).toBeTruthy();
+      });
+
+      it('should display correct stock name, price, currency', () => {
+        expect(getStocks().nativeElement.textContent.trim()).toEqual(
+          `${symbol} ${last} ${ccy}`
+        );
+      });
+
+      it('should display correct exchange', () => {
+        expect(getExchange().nativeElement.textContent.trim()).toEqual(
+          exchange
+        );
+      });
+
+      it('should display correct change', () => {
+        expect(getChange().nativeElement.textContent.trim()).toEqual(
+          `${change} (${changePercent})`
+        );
+      });
+    });
   });
 });

--- a/src/app/examples/stock-market/stock-market.reducer.ts
+++ b/src/app/examples/stock-market/stock-market.reducer.ts
@@ -80,6 +80,9 @@ export interface Stock {
   last: string;
   ccy: string;
   change: string;
+  changePositive: boolean;
+  changeNegative: boolean;
+  changePercent: string;
 }
 
 export interface StockMarketState {


### PR DESCRIPTION
Closes #243 
Used ```given\when\then``` pattern.
Basically, my reasoning behind introducing this kind of nesting was the case of 
```'and stock details are loaded'``` where multiple checks are required though generally it's better not to bloat the ```it``` statement with unrelated ```expect``` checks. @tomastrajan if you have suggestions how to make it better I would greatly appreciate. Thank You!