### PR TITLE
refactor(Core): Add App state

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -13,7 +13,8 @@ import {
   AnimationsService,
   TitleService,
   selectAuth,
-  routeAnimations
+  routeAnimations,
+  AppState
 } from '@app/core';
 import { environment as env } from '@env/environment';
 
@@ -58,7 +59,7 @@ export class AppComponent implements OnInit, OnDestroy {
 
   constructor(
     public overlayContainer: OverlayContainer,
-    private store: Store<any>,
+    private store: Store<AppState>,
     private router: Router,
     private titleService: TitleService,
     private animationService: AnimationsService,

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -12,7 +12,7 @@ import {
   ActionAuthLogout,
   AnimationsService,
   TitleService,
-  selectorAuth,
+  selectAuth,
   routeAnimations
 } from '@app/core';
 import { environment as env } from '@env/environment';
@@ -101,7 +101,7 @@ export class AppComponent implements OnInit, OnDestroy {
 
   private subscribeToIsAuthenticated() {
     this.store
-      .pipe(select(selectorAuth), takeUntil(this.unsubscribe$))
+      .pipe(select(selectAuth), takeUntil(this.unsubscribe$))
       .subscribe(auth => (this.isAuthenticated = auth.isAuthenticated));
   }
 

--- a/src/app/core/auth/auth-guard.service.ts
+++ b/src/app/core/auth/auth-guard.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { CanActivate } from '@angular/router';
 import { Store, select } from '@ngrx/store';
 
-import { selectorAuth } from './auth.reducer';
+import { selectAuth } from './auth.selectors';
 
 @Injectable()
 export class AuthGuardService implements CanActivate {
@@ -10,7 +10,7 @@ export class AuthGuardService implements CanActivate {
 
   constructor(private store: Store<any>) {
     this.store
-      .pipe(select(selectorAuth))
+      .pipe(select(selectAuth))
       .subscribe(auth => (this.isAuthenticated = auth.isAuthenticated));
   }
   canActivate(): boolean {

--- a/src/app/core/auth/auth-guard.service.ts
+++ b/src/app/core/auth/auth-guard.service.ts
@@ -3,12 +3,13 @@ import { CanActivate } from '@angular/router';
 import { Store, select } from '@ngrx/store';
 
 import { selectAuth } from './auth.selectors';
+import { AppState } from '../core.state';
 
 @Injectable()
 export class AuthGuardService implements CanActivate {
   isAuthenticated = false;
 
-  constructor(private store: Store<any>) {
+  constructor(private store: Store<AppState>) {
     this.store
       .pipe(select(selectAuth))
       .subscribe(auth => (this.isAuthenticated = auth.isAuthenticated));

--- a/src/app/core/auth/auth.actions.ts
+++ b/src/app/core/auth/auth.actions.ts
@@ -1,0 +1,16 @@
+import { Action } from '@ngrx/store';
+
+export enum AuthActionTypes {
+  LOGIN = '[Auth] Login',
+  LOGOUT = '[Auth] Logout'
+}
+
+export class ActionAuthLogin implements Action {
+  readonly type = AuthActionTypes.LOGIN;
+}
+
+export class ActionAuthLogout implements Action {
+  readonly type = AuthActionTypes.LOGOUT;
+}
+
+export type AuthActions = ActionAuthLogin | ActionAuthLogout;

--- a/src/app/core/auth/auth.effects.ts
+++ b/src/app/core/auth/auth.effects.ts
@@ -9,9 +9,10 @@ import { LocalStorageService } from '../local-storage/local-storage.service';
 import {
   ActionAuthLogin,
   ActionAuthLogout,
-  AUTH_KEY,
   AuthActionTypes
-} from './auth.reducer';
+} from './auth.actions';
+
+export const AUTH_KEY = 'AUTH';
 
 @Injectable()
 export class AuthEffects {

--- a/src/app/core/auth/auth.models.ts
+++ b/src/app/core/auth/auth.models.ts
@@ -1,0 +1,3 @@
+export interface AuthState {
+  isAuthenticated: boolean;
+}

--- a/src/app/core/auth/auth.reducer.ts
+++ b/src/app/core/auth/auth.reducer.ts
@@ -1,27 +1,9 @@
-import { Action } from '@ngrx/store';
-
-export const AUTH_KEY = 'AUTH';
-
-export enum AuthActionTypes {
-  LOGIN = '[Auth] Login',
-  LOGOUT = '[Auth] Logout'
-}
-
-export class ActionAuthLogin implements Action {
-  readonly type = AuthActionTypes.LOGIN;
-}
-
-export class ActionAuthLogout implements Action {
-  readonly type = AuthActionTypes.LOGOUT;
-}
-
-export type AuthActions = ActionAuthLogin | ActionAuthLogout;
+import { AuthState } from './auth.models';
+import { AuthActions, AuthActionTypes } from './auth.actions';
 
 export const initialState: AuthState = {
   isAuthenticated: false
 };
-
-export const selectorAuth = state => state.auth;
 
 export function authReducer(
   state: AuthState = initialState,
@@ -37,8 +19,4 @@ export function authReducer(
     default:
       return state;
   }
-}
-
-export interface AuthState {
-  isAuthenticated: boolean;
 }

--- a/src/app/core/auth/auth.selectors.ts
+++ b/src/app/core/auth/auth.selectors.ts
@@ -1,0 +1,8 @@
+import { createSelector } from '@ngrx/store';
+import { selectAuthState } from '../core.state';
+import { AuthState } from './auth.models';
+
+export const selectAuth = createSelector(
+  selectAuthState,
+  (state: AuthState) => state
+);

--- a/src/app/core/auth/auth.selectors.ts
+++ b/src/app/core/auth/auth.selectors.ts
@@ -1,4 +1,5 @@
 import { createSelector } from '@ngrx/store';
+
 import { selectAuthState } from '../core.state';
 import { AuthState } from './auth.models';
 

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -1,31 +1,19 @@
 import { NgModule, Optional, SkipSelf } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HttpClientModule, HttpClient } from '@angular/common/http';
-import { MetaReducer, StoreModule } from '@ngrx/store';
+import { StoreModule } from '@ngrx/store';
 import { EffectsModule } from '@ngrx/effects';
-import { storeFreeze } from 'ngrx-store-freeze';
 import { TranslateModule, TranslateLoader } from '@ngx-translate/core';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 
 import { environment } from '@env/environment';
 
-import { debug } from './meta-reducers/debug.reducer';
-import { initStateFromLocalStorage } from './meta-reducers/init-state-from-local-storage.reducer';
 import { LocalStorageService } from './local-storage/local-storage.service';
-import { authReducer } from './auth/auth.reducer';
 import { AuthEffects } from './auth/auth.effects';
 import { AuthGuardService } from './auth/auth-guard.service';
 import { AnimationsService } from './animations/animations.service';
 import { TitleService } from './title/title.service';
-
-export const metaReducers: MetaReducer<any>[] = [initStateFromLocalStorage];
-
-if (!environment.production) {
-  metaReducers.unshift(storeFreeze);
-  if (!environment.test) {
-    metaReducers.unshift(debug);
-  }
-}
+import { reducers, metaReducers } from './core.state';
 
 @NgModule({
   imports: [
@@ -34,12 +22,7 @@ if (!environment.production) {
     HttpClientModule,
 
     // ngrx
-    StoreModule.forRoot(
-      {
-        auth: authReducer
-      },
-      { metaReducers }
-    ),
+    StoreModule.forRoot(reducers, { metaReducers: metaReducers() }),
     EffectsModule.forRoot([AuthEffects]),
 
     // 3rd party

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -22,7 +22,7 @@ import { reducers, metaReducers } from './core.state';
     HttpClientModule,
 
     // ngrx
-    StoreModule.forRoot(reducers, { metaReducers: metaReducers() }),
+    StoreModule.forRoot(reducers, { metaReducers }),
     EffectsModule.forRoot([AuthEffects]),
 
     // 3rd party

--- a/src/app/core/core.state.ts
+++ b/src/app/core/core.state.ts
@@ -4,30 +4,32 @@ import {
   createFeatureSelector
 } from '@ngrx/store';
 import { storeFreeze } from 'ngrx-store-freeze';
+
+import { environment } from '@env/environment';
+
 import { initStateFromLocalStorage } from './meta-reducers/init-state-from-local-storage.reducer';
 import { debug } from './meta-reducers/debug.reducer';
 import { AuthState } from './auth/auth.models';
 import { authReducer } from './auth/auth.reducer';
-import { environment } from '@env/environment';
 
-export const reducers: ActionReducerMap<State> = {
+export const reducers: ActionReducerMap<AppState> = {
   auth: authReducer
 };
 
-export const metaReducers = (): MetaReducer<State>[] => {
-  // tslint:disable-next-line:prefer-const
-  let metas = [initStateFromLocalStorage];
-  if (!environment.production) {
-    metas.unshift(storeFreeze);
-    if (!environment.test) {
-      metas.unshift(debug);
-    }
+export const metaReducers: MetaReducer<AppState>[] = [
+  initStateFromLocalStorage
+];
+if (!environment.production) {
+  metaReducers.unshift(storeFreeze);
+  if (!environment.test) {
+    metaReducers.unshift(debug);
   }
-  return metas;
-};
+}
 
-export const selectAuthState = createFeatureSelector<State, AuthState>('auth');
+export const selectAuthState = createFeatureSelector<AppState, AuthState>(
+  'auth'
+);
 
-export interface State {
+export interface AppState {
   auth: AuthState;
 }

--- a/src/app/core/core.state.ts
+++ b/src/app/core/core.state.ts
@@ -1,0 +1,33 @@
+import {
+  ActionReducerMap,
+  MetaReducer,
+  createFeatureSelector
+} from '@ngrx/store';
+import { storeFreeze } from 'ngrx-store-freeze';
+import { initStateFromLocalStorage } from './meta-reducers/init-state-from-local-storage.reducer';
+import { debug } from './meta-reducers/debug.reducer';
+import { AuthState } from './auth/auth.models';
+import { authReducer } from './auth/auth.reducer';
+import { environment } from '@env/environment';
+
+export const reducers: ActionReducerMap<State> = {
+  auth: authReducer
+};
+
+export const metaReducers = (): MetaReducer<State>[] => {
+  // tslint:disable-next-line:prefer-const
+  let metas = [initStateFromLocalStorage];
+  if (!environment.production) {
+    metas.unshift(storeFreeze);
+    if (!environment.test) {
+      metas.unshift(debug);
+    }
+  }
+  return metas;
+};
+
+export const selectAuthState = createFeatureSelector<State, AuthState>('auth');
+
+export interface State {
+  auth: AuthState;
+}

--- a/src/app/core/index.ts
+++ b/src/app/core/index.ts
@@ -2,6 +2,8 @@ export * from './local-storage/local-storage.service';
 export * from './animations/route.animations';
 export * from './animations/animations.service';
 export * from './auth/auth.reducer';
+export * from './auth/auth.actions';
+export * from './auth/auth.selectors';
 export * from './auth/auth-guard.service';
 export * from './title/title.service';
 export * from './core.module';

--- a/src/app/core/index.ts
+++ b/src/app/core/index.ts
@@ -6,4 +6,5 @@ export * from './auth/auth.actions';
 export * from './auth/auth.selectors';
 export * from './auth/auth-guard.service';
 export * from './title/title.service';
+export * from './core.state';
 export * from './core.module';

--- a/src/app/core/meta-reducers/debug.reducer.ts
+++ b/src/app/core/meta-reducers/debug.reducer.ts
@@ -1,6 +1,10 @@
 import { ActionReducer } from '@ngrx/store';
 
-export function debug(reducer: ActionReducer<any>): ActionReducer<any> {
+import { AppState } from '../core.state';
+
+export function debug(
+  reducer: ActionReducer<AppState>
+): ActionReducer<AppState> {
   return function(state, action) {
     const newState = reducer(state, action);
     console.log(`[DEBUG] action: ${action.type}`, {

--- a/src/app/core/meta-reducers/init-state-from-local-storage.reducer.ts
+++ b/src/app/core/meta-reducers/init-state-from-local-storage.reducer.ts
@@ -1,10 +1,11 @@
 import { ActionReducer, INIT, UPDATE } from '@ngrx/store';
 
 import { LocalStorageService } from '../local-storage/local-storage.service';
+import { AppState } from '../core.state';
 
 export function initStateFromLocalStorage(
-  reducer: ActionReducer<any>
-): ActionReducer<any> {
+  reducer: ActionReducer<AppState>
+): ActionReducer<AppState> {
   return function(state, action) {
     const newState = reducer(state, action);
     if ([INIT.toString(), UPDATE.toString()].includes(action.type)) {

--- a/src/app/examples/examples.state.ts
+++ b/src/app/examples/examples.state.ts
@@ -1,5 +1,7 @@
 import { createFeatureSelector, ActionReducerMap } from '@ngrx/store';
 
+import { AppState } from '@app/core';
+
 import { todosReducer } from './todos/todos.reducer';
 import { TodosState } from './todos/todos.model';
 import { stockMarketReducer } from './stock-market/stock-market.reducer';
@@ -12,11 +14,15 @@ export const reducers: ActionReducerMap<ExamplesState> = {
   stockMarket: stockMarketReducer
 };
 
-export const selectExamples = createFeatureSelector<any, ExamplesState>(
+export const selectExamples = createFeatureSelector<State, ExamplesState>(
   FEATURE_NAME
 );
 
 export interface ExamplesState {
   todos: TodosState;
   stockMarket: StockMarketState;
+}
+
+export interface State extends AppState {
+  examples: ExamplesState;
 }

--- a/src/app/examples/examples/examples.component.ts
+++ b/src/app/examples/examples/examples.component.ts
@@ -7,6 +7,7 @@ import { Subject } from 'rxjs';
 
 import { routeAnimations, TitleService } from '@app/core';
 import { selectorSettings, SettingsState } from '@app/settings';
+import { State } from '../examples.state';
 
 @Component({
   selector: 'anms-examples',
@@ -25,7 +26,7 @@ export class ExamplesComponent implements OnInit, OnDestroy {
   ];
 
   constructor(
-    private store: Store<any>,
+    private store: Store<State>,
     private router: Router,
     private titleService: TitleService,
     private translate: TranslateService

--- a/src/app/examples/stock-market/components/stock-market-container.component.spec.ts
+++ b/src/app/examples/stock-market/components/stock-market-container.component.spec.ts
@@ -10,11 +10,12 @@ import { ExamplesModule } from '../../examples.module';
 import { ActionStockMarketRetrieve } from '../stock-market.actions';
 import { StockMarketState } from '../stock-market.model';
 import { StockMarketContainerComponent } from './stock-market-container.component';
+import { State } from '../../examples.state';
 
 describe('StockMarketContainerComponent', () => {
   let component: StockMarketContainerComponent;
   let fixture: ComponentFixture<StockMarketContainerComponent>;
-  let store: MockStore<any>;
+  let store: MockStore<State>;
 
   const getSpinner = () => fixture.debugElement.query(By.css('mat-spinner'));
 
@@ -172,5 +173,5 @@ function createState(stockState: StockMarketState) {
     examples: {
       stockMarket: stockState
     }
-  };
+  } as State;
 }

--- a/src/app/examples/stock-market/components/stock-market-container.component.ts
+++ b/src/app/examples/stock-market/components/stock-market-container.component.ts
@@ -5,6 +5,7 @@ import { takeUntil } from 'rxjs/operators';
 
 import { selectStockMarket } from '../stock-market.selectors';
 import { ActionStockMarketRetrieve } from '../stock-market.actions';
+import { State } from '../../examples.state';
 
 @Component({
   selector: 'anms-stock-market',
@@ -17,7 +18,7 @@ export class StockMarketContainerComponent implements OnInit, OnDestroy {
   initialized;
   stocks;
 
-  constructor(public store: Store<any>) {}
+  constructor(public store: Store<State>) {}
 
   ngOnInit() {
     this.initialized = false;

--- a/src/app/examples/todos/components/todos-container.component.spec.ts
+++ b/src/app/examples/todos/components/todos-container.component.spec.ts
@@ -11,11 +11,12 @@ import {
 } from '../todos.actions';
 import { TodosState } from '../todos.model';
 import { TodosContainerComponent } from './todos-container.component';
+import { State } from '../../examples.state';
 
 describe('TodosComponent', () => {
   let component: TodosContainerComponent;
   let fixture: ComponentFixture<TodosContainerComponent>;
-  let store: MockStore<any>;
+  let store: MockStore<State>;
   let dispatchSpy;
 
   const getTodos = () => fixture.debugElement.queryAll(By.css('.todo'));
@@ -200,5 +201,5 @@ function createState(todoState: TodosState) {
     examples: {
       todos: todoState
     }
-  };
+  } as State;
 }

--- a/src/app/examples/todos/components/todos-container.component.ts
+++ b/src/app/examples/todos/components/todos-container.component.ts
@@ -15,6 +15,7 @@ import {
 } from '../todos.actions';
 import { selectTodos } from '../todos.selectors';
 import { Todo, TodosFilter, TodosState } from '../todos.model';
+import { State } from '../../examples.state';
 
 @Component({
   selector: 'anms-todos',
@@ -28,7 +29,7 @@ export class TodosContainerComponent implements OnInit, OnDestroy {
   todos: TodosState;
   newTodo = '';
 
-  constructor(public store: Store<any>, public snackBar: MatSnackBar) {}
+  constructor(public store: Store<State>, public snackBar: MatSnackBar) {}
 
   ngOnInit() {
     this.store


### PR DESCRIPTION
This PR adds an `AppState` to the application.
In order to make this possible I also split up the `auth` reducer, as @tomastrajan previously did for the example states.

What still has to be done is the verification that there is no unexpected appstate in the feature module's bundle with `npm run analyze`. I have taken a look and I think it should be OK, but please do verify it because this was new to me 😅 .

Closes #304 