### PR TITLE
refactor(auth): use observable in auth guard

### DIFF
--- a/src/app/core/auth/auth-guard.service.ts
+++ b/src/app/core/auth/auth-guard.service.ts
@@ -1,20 +1,20 @@
 import { Injectable } from '@angular/core';
 import { CanActivate } from '@angular/router';
 import { Store, select } from '@ngrx/store';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 import { selectAuth } from './auth.selectors';
 import { AppState } from '../core.state';
 
 @Injectable()
 export class AuthGuardService implements CanActivate {
-  isAuthenticated = false;
+  constructor(private store: Store<AppState>) {}
 
-  constructor(private store: Store<AppState>) {
-    this.store
-      .pipe(select(selectAuth))
-      .subscribe(auth => (this.isAuthenticated = auth.isAuthenticated));
-  }
-  canActivate(): boolean {
-    return this.isAuthenticated;
+  canActivate(): Observable<boolean> {
+    return this.store.pipe(
+      select(selectAuth),
+      map(auth => auth.isAuthenticated)
+    );
   }
 }

--- a/src/app/examples/examples/examples.component.html
+++ b/src/app/examples/examples/examples.component.html
@@ -4,7 +4,7 @@
      [routerLink]="e.link"
      routerLinkActive #rla="routerLinkActive"
      [active]="rla.isActive"
-     [disabled]="e.link == 'authenticated' && !auth.isAuthenticated">
+     [disabled]="e.auth && !(isAuthenticated$ | async)">
     {{e.label | translate}}
   </a>
 </nav>

--- a/src/app/examples/examples/examples.component.ts
+++ b/src/app/examples/examples/examples.component.ts
@@ -2,13 +2,14 @@ import { Store, select } from '@ngrx/store';
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { ActivationEnd, Router } from '@angular/router';
+import { Observable, Subject } from 'rxjs';
 import { filter, takeUntil, map } from 'rxjs/operators';
-import { Subject } from 'rxjs';
 
-import { routeAnimations, TitleService, AuthGuardService } from '@app/core';
+import { routeAnimations, TitleService } from '@app/core';
 import { selectSettings, SettingsState } from '@app/settings';
 
 import { State } from '../examples.state';
+import { selectAuth } from '@app/core/auth/auth.selectors';
 
 @Component({
   selector: 'anms-examples',
@@ -18,26 +19,30 @@ import { State } from '../examples.state';
 })
 export class ExamplesComponent implements OnInit, OnDestroy {
   private unsubscribe$: Subject<void> = new Subject<void>();
+  private isAuthenticated$: Observable<boolean>;
 
   examples = [
     { link: 'todos', label: 'anms.examples.menu.todos' },
     { link: 'stock-market', label: 'anms.examples.menu.stocks' },
     { link: 'theming', label: 'anms.examples.menu.theming' },
-    { link: 'authenticated', label: 'anms.examples.menu.auth' }
+    { link: 'authenticated', label: 'anms.examples.menu.auth', auth: true }
   ];
 
   constructor(
     private store: Store<State>,
     private router: Router,
     private titleService: TitleService,
-    private translate: TranslateService,
-    private auth: AuthGuardService
+    private translate: TranslateService
   ) {}
 
   ngOnInit(): void {
     this.translate.setDefaultLang('en');
     this.subscribeToSettings();
     this.subscribeToRouterEvents();
+    this.isAuthenticated$ = this.store.pipe(
+      select(selectAuth),
+      map(auth => auth.isAuthenticated)
+    );
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
@matiasiglesias @Jeykairis adjusted the auth guard and introduced `auth` flag for menu items that should be available only for authenticated users. This could be changed in the future into roles so instead of boolean flag it can be a role name array...