### PR TITLE
test(auth): add unit test for auth selectors, closes #336

### DIFF
--- a/src/app/core/auth/auth.selectors.spec.ts
+++ b/src/app/core/auth/auth.selectors.spec.ts
@@ -1,0 +1,19 @@
+import { selectAuth, selectIsAuthenticated } from './auth.selectors';
+
+const createAuthState = ({ isAuthenticated = false } = {}) => ({
+  auth: {
+    isAuthenticated
+  }
+});
+
+describe('Auth Selectors', () => {
+  const state = createAuthState();
+
+  it('selectAuth', () => {
+    expect(selectAuth(state)).toBe(state.auth);
+  });
+
+  it('selectIsAuthenticated', () => {
+    expect(selectIsAuthenticated(state)).toBe(state.auth.isAuthenticated);
+  });
+});

--- a/src/app/core/auth/auth.selectors.spec.ts
+++ b/src/app/core/auth/auth.selectors.spec.ts
@@ -1,19 +1,21 @@
 import { selectAuth, selectIsAuthenticated } from './auth.selectors';
 
-const createAuthState = ({ isAuthenticated = false } = {}) => ({
-  auth: {
-    isAuthenticated
-  }
-});
-
 describe('Auth Selectors', () => {
-  const state = createAuthState();
-
   it('selectAuth', () => {
+    const state = createAuthState();
     expect(selectAuth(state)).toBe(state.auth);
   });
 
   it('selectIsAuthenticated', () => {
-    expect(selectIsAuthenticated(state)).toBe(state.auth.isAuthenticated);
+    const state = createAuthState();
+    expect(selectIsAuthenticated(state)).toBe(false);
   });
 });
+
+function createAuthState() {
+  return {
+    auth: {
+      isAuthenticated: false
+    }
+  };
+}

--- a/src/app/core/auth/auth.selectors.ts
+++ b/src/app/core/auth/auth.selectors.ts
@@ -7,3 +7,8 @@ export const selectAuth = createSelector(
   selectAuthState,
   (state: AuthState) => state
 );
+
+export const selectIsAuthenticated = createSelector(
+  selectAuthState,
+  (state: AuthState) => state.isAuthenticated
+);


### PR DESCRIPTION
<!--

Hi, thanks for taking the time to submit this Pull Request, it is really appreciated!

Before submitting the Pull Request make sure you:

* are familiar with and follow the Code of Conduct for
  this project: CODE_OF_CONDUCT.md

* the commit message follows our guidelines: CONTRIBUTING.md#commit-message-guidelines

Feel free to add yourself as a contributor via `npm run contributors:add` and don't forget to run 
`npm run contributors:generate` after this. For example:

$ npm run contributors:add username code,test,translation
$ npm run contributors:generate

-->

## What:
<!-- What changes are being made, why are these changes necessary? -->
There is really no difference between selectAuth and selectAuthState, both are memoized selectors and they are returning the same values.

I did just add another selector for good practice, even though the AuthState is very small, so today there is no practical difference. Therefore I did not take it upon myself to change code where selectAuth is used.

But if the scenario instead would be
`auth: {
  isAuthenticated: false,
  someOtherProp: false
}`
and you only are interested in isAuthenticated. The selectAuth would result in multiple subscription triggers if someOtherProp would change. 
<!--  To automatically close the corresponding issue use: Closes #<issue-number, e.g. Closes #47 -->
Issue number: #336 
