### PR TITLE
test(stock-market): add stock market effects spec, closes #267

### DIFF
--- a/src/app/examples/stock-market/stock-market.effects.spec.ts
+++ b/src/app/examples/stock-market/stock-market.effects.spec.ts
@@ -1,0 +1,111 @@
+import { LocalStorageService } from '@app/core';
+import { Actions } from '@ngrx/effects';
+import { cold, getTestScheduler } from 'jasmine-marbles';
+import { of, throwError } from 'rxjs/';
+import {
+  ActionStockMarketRetrieve,
+  ActionStockMarketRetrieveError,
+  ActionStockMarketRetrieveSuccess
+} from './stock-market.actions';
+import { StockMarketEffects, STOCK_MARKET_KEY } from './stock-market.effects';
+import { Stock } from './stock-market.model';
+import { StockMarketService } from '@app/examples/stock-market/stock-market.service';
+
+describe('StockMarketEffects', () => {
+  let localStorage: jasmine.SpyObj<LocalStorageService>;
+  let stockMarket: jasmine.SpyObj<StockMarketService>;
+
+  beforeEach(() => {
+    localStorage = jasmine.createSpyObj('localStorageService', ['setItem']);
+    stockMarket = jasmine.createSpyObj('stockMarketService', ['retrieveStock']);
+  });
+
+  describe('retrieveStock', () => {
+    const symbol = 'TSLA';
+
+    it('should emit ActionStockMarketRetrieveSuccess on success', () => {
+      const retrieveAction1 = new ActionStockMarketRetrieve({
+        symbol
+      });
+      const retrieveAction2 = new ActionStockMarketRetrieve({
+        symbol
+      });
+      const retrieveAction3 = new ActionStockMarketRetrieve({
+        symbol
+      });
+      const stock: Stock = {
+        symbol,
+        exchange: 'exchange',
+        last: '42',
+        ccy: 'USD',
+        change: 'change',
+        changePositive: true,
+        changeNegative: false,
+        changePercent: '2.00'
+      };
+      const successAction = new ActionStockMarketRetrieveSuccess({
+        stock
+      });
+      const values = {
+        a: retrieveAction1,
+        b: retrieveAction2,
+        c: retrieveAction3,
+        s: successAction
+      };
+      const source = cold('a--b--c', values);
+      /* a is mapped into s and debounced by 20ms, b and c get discarded by distinct until changed */
+      const expected = cold('--s', values);
+      const actions = new Actions(source);
+
+      stockMarket.retrieveStock.and.returnValue(of(stock));
+
+      const effects = new StockMarketEffects(
+        actions,
+        localStorage,
+        stockMarket
+      );
+
+      expect(
+        effects.retrieveStock({
+          debounce: 20,
+          scheduler: getTestScheduler()
+        })
+      ).toBeObservable(expected);
+      expect(localStorage.setItem).toHaveBeenCalledWith(STOCK_MARKET_KEY, {
+        symbol
+      });
+    });
+
+    it('should emit ActionStockMarketRetrieveError on error', () => {
+      const retrieveAction = new ActionStockMarketRetrieve({
+        symbol
+      });
+      const error = 'ERROR';
+      const errorAction = new ActionStockMarketRetrieveError({
+        error
+      } as any);
+      const values = {
+        a: retrieveAction,
+        e: errorAction
+      };
+      const source = cold('a', values);
+      const expected = cold('--e', values);
+      const actions = new Actions(source);
+
+      stockMarket.retrieveStock.and.returnValue(throwError(error));
+
+      const effects = new StockMarketEffects(
+        actions,
+        localStorage,
+        stockMarket
+      );
+
+      expect(
+        effects.retrieveStock({
+          debounce: 20,
+          scheduler: getTestScheduler()
+        })
+      ).toBeObservable(expected);
+    });
+  });
+});

--- a/tslint.json
+++ b/tslint.json
@@ -91,7 +91,8 @@
     "radix": true,
     "semicolon": [
       true,
-      "always"
+      "always",
+      "ignore-bound-class-methods"
     ],
     "triple-equals": [
       true,


### PR DESCRIPTION
I wrote the tests without the TestBed as advised by Viktor Savkin in this example [repo](https://github.com/vsavkin/testing_ngrx_effects). If you feel that the tests should use TestBed I can refactor it without a problem.

I refactored the `retrieveStock` effect into a function, which allows for easier overrides of the debounceTime value and scheduler during testing. It follows the official effects testing [guide](https://github.com/ngrx/platform/blob/master/docs/effects/testing.md#effects-as-functions).

Finally, I fixed a bug with `distinctUntilChanged()` operator. Let me demonstrate it with the example:

Assuming we dispatch the following actions: 
```
{ type: 'RETRIEVE', payload: { symbol: 'TSLA' } }
{ type: 'RETRIEVE', payload: { symbol: 'TSLA' } }
{ type: 'RETRIEVE', payload: { symbol: 'TSLA' } }
```

By default `distinctUntilChanged()` uses === operator for equality check. Because every action is a new object, the operator will not filter anything, even though the actions have the exact same payload structure. 

Luckily, `distinctUntilChanged()` accepts a compare function as an argument and we can just compare the symbol to get the desired behavior.

```
distinctUntilChanged((x, y) => x.payload.symbol === y.payload.symbol)
```

