### PR TITLE
feat(): add UI notification for client and HTTP errors

### DIFF
--- a/src/app/app.component.scss-theme.scss
+++ b/src/app/app.component.scss-theme.scss
@@ -3,6 +3,7 @@
 @mixin anms-app-component-theme($theme) {
   $primary: map-get($theme, primary);
   $accent: map-get($theme, accent);
+  $warn: map-get($theme, warn);
 
   mat-sidenav-container {
     mat-toolbar {
@@ -44,6 +45,17 @@
           }
         }
       }
+    }
+  }
+
+  .error-notification-overlay {
+    color: mat-color($primary, default-contrast);
+    background-color: mat-color($warn);
+
+    button {
+      border-radius: 2px;
+      background-color: mat-color($accent);
+      color: mat-color($accent, default-contrast);
     }
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -14,7 +14,8 @@ import {
   TitleService,
   selectAuth,
   routeAnimations,
-  AppState
+  AppState,
+  LocalStorageService
 } from '@app/core';
 import { environment as env } from '@env/environment';
 
@@ -64,7 +65,8 @@ export class AppComponent implements OnInit, OnDestroy {
     private router: Router,
     private titleService: TitleService,
     private animationService: AnimationsService,
-    private translate: TranslateService
+    private translate: TranslateService,
+    private storageService: LocalStorageService
   ) {}
 
   private static trackPageView(event: NavigationEnd) {
@@ -81,6 +83,7 @@ export class AppComponent implements OnInit, OnDestroy {
     this.subscribeToSettings();
     this.subscribeToIsAuthenticated();
     this.subscribeToRouterEvents();
+    this.storageService.testLocalStorage();
   }
 
   ngOnDestroy(): void {

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -1,4 +1,4 @@
-import { NgModule, Optional, SkipSelf } from '@angular/core';
+import { NgModule, Optional, SkipSelf, ErrorHandler } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HttpClientModule, HttpClient } from '@angular/common/http';
 import { StoreModule } from '@ngrx/store';
@@ -15,6 +15,8 @@ import { AuthGuardService } from './auth/auth-guard.service';
 import { AnimationsService } from './animations/animations.service';
 import { TitleService } from './title/title.service';
 import { reducers, metaReducers } from './core.state';
+import { AppErrorHandler } from './error-handler/app-error-handler.service';
+import { httpInterceptorProviders } from '@app/core/http-interceptors';
 import {
   StoreRouterConnectingModule,
   RouterStateSerializer
@@ -51,7 +53,9 @@ import { CustomSerializer } from './router/custom-serializer';
     LocalStorageService,
     AuthGuardService,
     AnimationsService,
+    httpInterceptorProviders,
     TitleService,
+    { provide: ErrorHandler, useClass: AppErrorHandler },
     { provide: RouterStateSerializer, useClass: CustomSerializer }
   ],
   exports: [TranslateModule]

--- a/src/app/core/error-handler/app-error-handler.service.ts
+++ b/src/app/core/error-handler/app-error-handler.service.ts
@@ -1,0 +1,37 @@
+import { Injectable, ErrorHandler, NgZone } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { environment } from '@env/environment';
+
+/** Application-wide error handler that adds a UI notification to the error handling
+ * provided by the default Angular ErrorHandler.
+ */
+@Injectable()
+export class AppErrorHandler extends ErrorHandler {
+  constructor(private snackBar: MatSnackBar, private readonly zone: NgZone) {
+    super();
+  }
+
+  handleError(error: Error | HttpErrorResponse) {
+    let displayMessage = 'An error occurred.';
+
+    if (!environment.production) {
+      displayMessage += ' See console for details.';
+    }
+
+    this.showNotification(displayMessage, 'Error');
+
+    super.handleError(error);
+  }
+
+  private showNotification(message: string, action?: string) {
+    // Need to open snackBar from Angular zone to prevent issues with its position per
+    // https://stackoverflow.com/questions/50101912/snackbar-position-wrong-when-use-errorhandler-in-angular-5-and-material
+    this.zone.run(() =>
+      this.snackBar.open(message, action, {
+        duration: 3000,
+        panelClass: 'error-notification-overlay'
+      })
+    );
+  }
+}

--- a/src/app/core/http-interceptors/http-error.interceptor.ts
+++ b/src/app/core/http-interceptors/http-error.interceptor.ts
@@ -1,0 +1,30 @@
+import { Injectable, Injector, ErrorHandler } from '@angular/core';
+import {
+  HttpEvent,
+  HttpInterceptor,
+  HttpHandler,
+  HttpRequest,
+  HttpErrorResponse
+} from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+
+/** Passes HttpErrorResponse to application-wide error handler */
+@Injectable()
+export class HttpErrorInterceptor implements HttpInterceptor {
+  constructor(private injector: Injector) {}
+
+  intercept(
+    request: HttpRequest<any>,
+    next: HttpHandler
+  ): Observable<HttpEvent<any>> {
+    return next.handle(request).pipe(
+      tap(null, (err: any) => {
+        if (err instanceof HttpErrorResponse) {
+          const appErrorHandler = this.injector.get(ErrorHandler);
+          appErrorHandler.handleError(err);
+        }
+      })
+    );
+  }
+}

--- a/src/app/core/http-interceptors/index.ts
+++ b/src/app/core/http-interceptors/index.ts
@@ -1,0 +1,9 @@
+/* "Barrel" of Http Interceptors; see HttpClient docs and sample code for more info */
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
+
+import { HttpErrorInterceptor } from './http-error.interceptor';
+
+/** Http interceptor providers in outside-in order */
+export const httpInterceptorProviders = [
+  { provide: HTTP_INTERCEPTORS, useClass: HttpErrorInterceptor, multi: true }
+];

--- a/src/app/core/local-storage/local-storage.service.spec.ts
+++ b/src/app/core/local-storage/local-storage.service.spec.ts
@@ -18,9 +18,17 @@ describe('LocalStorageService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should get and set the item', () => {
+  it('testLocalStorage should be executable', () => {
+    spyOn(service, 'testLocalStorage');
+    service.testLocalStorage();
+    expect(service.testLocalStorage).toHaveBeenCalled();
+  });
+
+  it('should get, set, and remove the item', () => {
     service.setItem('TEST', 'item');
     expect(service.getItem('TEST')).toBe('item');
+    service.removeItem('TEST');
+    expect(service.getItem('TEST')).toBe(null);
   });
 
   it('should load initial state', () => {

--- a/src/app/core/local-storage/local-storage.service.ts
+++ b/src/app/core/local-storage/local-storage.service.ts
@@ -45,4 +45,24 @@ export class LocalStorageService {
   getItem(key: string) {
     return JSON.parse(localStorage.getItem(`${APP_PREFIX}${key}`));
   }
+
+  removeItem(key: string) {
+    localStorage.removeItem(`${APP_PREFIX}${key}`);
+  }
+
+  /** Tests that localStorage exists, can be written to, and read from. */
+  testLocalStorage() {
+    const testValue = 'testValue';
+    const testKey = 'testKey';
+    let retrievedValue: string;
+    const errorMessage = 'localStorage did not return expected value';
+
+    this.setItem(testKey, testValue);
+    retrievedValue = this.getItem(testKey);
+    this.removeItem(testKey);
+
+    if (retrievedValue !== testValue) {
+      throw new Error(errorMessage);
+    }
+  }
 }

--- a/src/app/examples/stock-market/stock-market.service.spec.ts
+++ b/src/app/examples/stock-market/stock-market.service.spec.ts
@@ -3,6 +3,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { HttpClient } from '@angular/common/http';
 import { of } from 'rxjs';
 
+import { SharedModule } from '@app/shared';
 import { CoreModule } from '@app/core';
 
 import { StockMarketService } from './stock-market.service';
@@ -14,7 +15,7 @@ describe('StockMarketService', () => {
     httpClientSpy = jasmine.createSpyObj('HttpClient', ['get']);
 
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, CoreModule],
+      imports: [RouterTestingModule, CoreModule, SharedModule],
       providers: [
         StockMarketService,
         { provide: HttpClient, useValue: httpClientSpy }


### PR DESCRIPTION
Added application-wide error handler that shows a UI notification
for any client or HTTP error before passing the error to
the default Angular ErrorHandler.

closes #321

Please see #360 for review comments for the previous version of my changes.