### PR TITLE
fix(app): Double scrollbar on page transition in long pages. fixes #400

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -70,8 +70,7 @@ mat-sidenav-container {
     .content {
       flex: 1 0 auto;
       margin-top: 64px;
-      overflow-y: auto;
-      overflow-x: hidden;
+      overflow: hidden;
     }
 
     .footer {


### PR DESCRIPTION
## What:
I changed overflow-y axis from auto to hidden. And also I changed overflow-x and -y to one overflow property.
I checked if it works correctly in Chrome, IE and Edge.

Issue number:  #400
