### PR TITLE
feat(docker): dockerfile for production

### DIFF
--- a/Production.Dockerfile
+++ b/Production.Dockerfile
@@ -1,0 +1,35 @@
+FROM node:11.1.0 as npm_builder
+# Set the entrypoint as bin bash incase we want to inspect the container
+ENTRYPOINT ["/bin/bash"]
+# Manually copy the package.json
+COPY ./package.json /usr/src/app/package.json
+COPY ./package-lock.json /usr/src/app/package-lock.json
+COPY cypress /usr/src/app/cypress
+# Set the work directory to where we copied our source files
+WORKDIR /usr/src/app
+# Install all of our dependencies
+RUN npm install
+
+FROM npm_builder as builder
+# Copy the app excluding everything in the .dockerignore
+COPY . /usr/src/app
+# Put node_modules into the path, this will purely be used for accessing the angular cli
+ENV PATH /usr/src/app/node_modules/.bin:$PATH
+# Set the work directory to where we copied our source files
+WORKDIR /usr/src/app
+# Build our distributable
+RUN npm run build:prod
+
+FROM node:11.1.0 as production
+# Copy the dist folder from builder
+COPY --from=builder /usr/src/app/dist /usr/src/app/dist
+COPY --from=builder /usr/src/app/server.js /usr/src/app/server.js
+# Set the work directory to where we copied our source files
+WORKDIR /usr/src/app
+RUN npm install compression@1.7.3
+RUN npm install express@4.16.4
+# Create 2 empty environment variables
+ENV CONTEXT=
+ENV PORT=
+# Run the node server which should be used for production
+CMD ["node", "server.js"]

--- a/Production.docker-compose.yml
+++ b/Production.docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.7'
+services:
+  web:
+    image: persistentcontainerregistry.azurecr.io/brothinjord.client
+    container_name: b_client
+    build:
+      context: .
+      dockerfile: Production.Dockerfile
+      target: production
+    environment:
+      - CONTEXT=angular-ngrx-material-starter
+      - PORT=150
+    ports:
+      - '100:150'

--- a/README.md
+++ b/README.md
@@ -53,6 +53,24 @@ npm start
    -p 4200:4200 \
    --rm \
    material-starter` - starts `material-starter` container (you can access running application browsing http://localhost:4200) 
+
+### Serving a Docker image
+When you are ready to serve your application the process has been made simple through the use of `Production.Dockerfile` and `Production.docker-compose.yml`.
+
+From the root directory of the project simply run `docker-compose -f Production.docker-compose.yml build`. After this has run you can test your image locally by running `docker-compose -f Production.docker-compose.yml up`. Run `docker-compose -f Production.docker-compose.yml down` once you are done looking over the website so that docker cleans up all the resources related to it.
+
+Npm scripts are also available to save having to write such a long command.
+
+#### Npm Scripts
+
+The following npm scripts correspond to the docker-compose commands.
+
+| Npm Script       | Docker Compose       |
+|------------------|----------------------|
+| docker:prod      | docker-compose build |
+| docker:prod-up   | docker-compose up    |
+| docker:prod-down | docker-compose down  |
+
 ## Make It Your Own
 When using this starter project to build your own app you might consider some of the following steps:
   
@@ -126,6 +144,7 @@ Articles with content that explains various approaches used to build this starte
 * fully responsive design
 * angular-material and custom components in `SharedModule`
 * Cypress for end to end tests
+* `Production.Dockerfile` for quick and easy serving of your app
  
 ## Stack
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,10 @@
     "preaccessibility": "npm run build:prod -- --deploy-url \"/angular-ngrx-material-starter/\" --base-href \"/angular-ngrx-material-starter\"",
     "accessibility": "npm-run-all --parallel --race server accessibility:run",
     "accessibility:run": "pa11y-ci --threshold 250",
-    "compodoc": "compodoc -p src/tsconfig.app.json"
+    "compodoc": "compodoc -p src/tsconfig.app.json",
+    "docker:prod": "docker-compose -f Production.docker-compose.yml build",
+    "docker:prod-up": "docker-compose -f Production.docker-compose.yml up",
+    "docker:prod-down": "docker-compose -f Production.docker-compose.yml down"
   },
   "husky": {
     "hooks": {

--- a/server.js
+++ b/server.js
@@ -1,12 +1,12 @@
 const express = require('express');
 const compression = require('compression');
 
-const CONTEXT = '/angular-ngrx-material-starter';
-const PORT = 4000;
+const CONTEXT = `/${process.env.CONTEXT || 'angular-ngrx-material-starter'}`;
+const PORT = process.env.PORT || 4000;
 
 const app = express();
 
 app.use(compression());
 app.use(CONTEXT, express.static(__dirname + '/dist'));
 app.use('/', express.static(__dirname + '/dist'));
-app.listen(PORT, () => console.log(`App running on localhost:${PORT}/${CONTEXT}`));
+app.listen(PORT, () => console.log(`App running on http://localhost:${PORT}${CONTEXT}`));


### PR DESCRIPTION
## What:
* A `Production.Dockerfile` with 3 stages:
  * `npm_builder` so that docker can cache the `npm install` command so it is not re-run every time you make small code changes. 
  * `builder` which will run `build:prod`
  * `production` which is the final image and will take a fresh `node:11.1.0` image, copy the necessary files from the `builder` stage and then run `node server.js`
* A `Production.docker-compose.yml` which can be used to run and build the `Production.Dockerfile`. This can be run with `docker-compose -f Production.docker-compose.yml up`
* Updates to `server.js` which will take the port and context from environment variables, if those variables exist. Should not be a breaking change.
  * An update to remove the / and append it on CONTEXT instead so that I can control click the url from my VSCode terminal 😄 
---
Issue number: #385 
