### PR TITLE
refactor(styles): simplify the label's margin-bottom reset

### DIFF
--- a/src/styles-reset.scss
+++ b/src/styles-reset.scss
@@ -5,10 +5,6 @@
   }
 }
 
-label {
-  margin-bottom: 0;
-}
-
 code {
   white-space: nowrap;
   border-radius: 10px;

--- a/src/styles-variables.scss
+++ b/src/styles-variables.scss
@@ -5,6 +5,7 @@ $toolbar-breakpoint: 600px;
 $fa-font-path: '../node_modules/@fortawesome/fontawesome-free-webfonts/webfonts';
 
 $link-hover-decoration: none;
+$label-margin-bottom: 0;
 
 $grid-breakpoints: (
   xs: 0,


### PR DESCRIPTION
Since the following PR https://github.com/twbs/bootstrap/pull/25561, there is a variable for setting the label's margin-bottom. We don't need to manually reset it.