### PR TITLE
test(app):  settings, examples and google-analytics tests, closes #419

### DIFF
--- a/src/app/core/google-analytics/google-analytics.effects.spec.ts
+++ b/src/app/core/google-analytics/google-analytics.effects.spec.ts
@@ -1,0 +1,49 @@
+import { getEffectsMetadata } from '@ngrx/effects';
+import { cold } from 'jasmine-marbles';
+import { GoogleAnalyticsEffects } from './google-analytics.effects';
+import { NavigationEnd } from '@angular/router';
+
+describe('GoogleAnalyticsEffects', () => {
+  let router: any;
+  const ga = (<any>window).ga;
+
+  beforeEach(() => {
+    router = {
+      routerState: {
+        snapshot: {}
+      },
+      events: {
+        pipe() {}
+      }
+    };
+
+    (<any>window).ga = jasmine.createSpy('ga');
+  });
+
+  afterAll(() => {
+    (<any>window).ga = ga;
+  });
+
+  it('should not dispatch action', function() {
+    const effect = new GoogleAnalyticsEffects(router);
+    const metadata = getEffectsMetadata(effect);
+
+    expect(metadata.pageView).toEqual({ dispatch: false });
+  });
+
+  it('should call google analytics', function() {
+    const routerEvent = new NavigationEnd(1, '', '');
+    router.events = cold('a', { a: routerEvent });
+    const effect = new GoogleAnalyticsEffects(router);
+
+    effect.pageView.subscribe(() => {
+      expect((<any>window).ga).toHaveBeenCalled();
+      expect((<any>window).ga).toHaveBeenCalledWith(
+        'set',
+        'page',
+        routerEvent.urlAfterRedirects
+      );
+      expect((<any>window).ga).toHaveBeenCalledWith('send', 'pageview');
+    });
+  });
+});

--- a/src/app/examples/examples.effects.spec.ts
+++ b/src/app/examples/examples.effects.spec.ts
@@ -1,0 +1,93 @@
+import { Actions, getEffectsMetadata } from '@ngrx/effects';
+import { TranslateService } from '@ngx-translate/core';
+import { Store } from '@ngrx/store';
+import { cold, hot } from 'jasmine-marbles';
+
+import {
+  ActionSettingsChangeLanguage,
+  SettingsActions,
+  State
+} from '@app/settings';
+import { ActivationEnd } from '@angular/router';
+import { TitleService } from '@app/core';
+import { ExamplesEffects } from './examples.effects';
+
+describe('SettingsEffects', () => {
+  let router: any;
+  let titleService: jasmine.SpyObj<TitleService>;
+  let translateService: jasmine.SpyObj<TranslateService>;
+  let store: jasmine.SpyObj<Store<State>>;
+
+  beforeEach(() => {
+    router = {
+      routerState: {
+        snapshot: {
+          root: {}
+        }
+      },
+      events: {
+        pipe() {}
+      }
+    };
+
+    titleService = jasmine.createSpyObj('TitleService', ['setTitle']);
+    translateService = jasmine.createSpyObj('TranslateService', ['use']);
+    store = jasmine.createSpyObj('store', ['pipe']);
+  });
+
+  describe('setTranslateServiceLanguage', () => {
+    it('should not dispatch action', function() {
+      const actions = new Actions<SettingsActions>();
+      const effect = new ExamplesEffects(
+        actions,
+        store,
+        translateService,
+        router,
+        titleService
+      );
+      const metadata = getEffectsMetadata(effect);
+
+      expect(metadata.setTranslateServiceLanguage).toEqual({ dispatch: false });
+    });
+  });
+
+  describe('setTitle', () => {
+    it('should not dispatch action', function() {
+      const actions = new Actions<SettingsActions>();
+      const effect = new ExamplesEffects(
+        actions,
+        store,
+        translateService,
+        router,
+        titleService
+      );
+      const metadata = getEffectsMetadata(effect);
+
+      expect(metadata.setTitle).toEqual({ dispatch: false });
+    });
+
+    it('should setTitle', function() {
+      const action = new ActionSettingsChangeLanguage({ language: 'en' });
+      const actions = hot('-a', { a: action });
+
+      const routerEvent = new ActivationEnd(router.routerState.snapshot);
+      router.events = cold('a', { a: routerEvent });
+
+      const effect = new ExamplesEffects(
+        actions,
+        store,
+        translateService,
+        router,
+        titleService
+      );
+
+      effect.setTitle.subscribe(() => {
+        expect(titleService.setTitle).toHaveBeenCalled();
+        expect(titleService.setTitle).toHaveBeenCalledWith(
+          router.routerState.snapshot.root,
+          translateService
+        );
+      });
+    });
+  });
+});

--- a/src/app/settings/settings.actions.spec.ts
+++ b/src/app/settings/settings.actions.spec.ts
@@ -3,6 +3,7 @@ import {
   ActionSettingsChangeAnimationsPage,
   ActionSettingsChangeAnimationsPageDisabled,
   ActionSettingsChangeAutoNightMode,
+  ActionSettingsChangeHour,
   ActionSettingsChangeLanguage,
   ActionSettingsChangeStickyHeader,
   ActionSettingsChangeTheme,
@@ -76,5 +77,14 @@ describe('Settings Actions', () => {
 
     expect(action.type).toEqual(SettingsActionTypes.CHANGE_STICKY_HEADER);
     expect(action.payload.stickyHeader).toEqual(true);
+  });
+
+  it('should create ActionSettingsChangeHour action', () => {
+    const action = new ActionSettingsChangeHour({
+      hour: 7
+    });
+
+    expect(action.type).toEqual(SettingsActionTypes.CHANGE_HOUR);
+    expect(action.payload.hour).toEqual(7);
   });
 });

--- a/src/app/settings/settings.reducer.spec.ts
+++ b/src/app/settings/settings.reducer.spec.ts
@@ -7,7 +7,8 @@ import {
   ActionSettingsChangeAutoNightMode,
   ActionSettingsChangeLanguage,
   ActionSettingsChangeTheme,
-  ActionSettingsChangeStickyHeader
+  ActionSettingsChangeStickyHeader,
+  ActionSettingsChangeHour
 } from './settings.actions';
 
 describe('SettingsReducer', () => {
@@ -68,5 +69,13 @@ describe('SettingsReducer', () => {
     });
     const state = settingsReducer(undefined, action);
     expect(state.stickyHeader).toEqual(false);
+  });
+
+  it('should update hour', () => {
+    const action = new ActionSettingsChangeHour({
+      hour: 7
+    });
+    const state = settingsReducer(undefined, action);
+    expect(state.hour).toEqual(7);
   });
 });


### PR DESCRIPTION
Add tests for  settings actions and reducers, examples effects and google-analytics effects.

@timdeschryver, wasn't able to test the `changeLanguage` effect from the examples module.
Could you provide some guidance on that please?