### PR TITLE
Fix stock reload upon revisiting the page

### DIFF
--- a/src/app/examples/stock-market/stock-market.effects.ts
+++ b/src/app/examples/stock-market/stock-market.effects.ts
@@ -37,7 +37,6 @@ export class StockMarketEffects {
           symbol: action.payload.symbol
         })
       ),
-      distinctUntilChanged((x, y) => x.payload.symbol === y.payload.symbol),
       debounceTime(debounce, scheduler),
       switchMap((action: ActionStockMarketRetrieve) =>
         this.service.retrieveStock(action.payload.symbol).pipe(


### PR DESCRIPTION
## What:
Remove distinct check, to ensure the data loads again after loading previously, debounce should be enough.

Issue number: #436
