### PR TITLE
cypress package version updated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5476,9 +5476,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.1.1.tgz",
-      "integrity": "sha512-0i5xd+UrYPlRF8uCcJcVwGeez8uxj4oXGIjg5a6GKtko2YRybOTNCABtFi6SEXUM4khqf+Qt3cVpo67R8ym3iA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.1.3.tgz",
+      "integrity": "sha512-ZusTQffKBVrLDvcxEinymTH0iCUL7hM1m6q9X+557wDtpd6S4et330QQE1IW10Pnyp+vYIHpkWxDm43B9G14nA==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "0.4.1",
@@ -5513,7 +5513,7 @@
         "lodash": "4.17.10",
         "log-symbols": "2.2.0",
         "minimist": "1.2.0",
-        "progress": "1.1.8",
+        "moment": "2.22.2",
         "ramda": "0.24.1",
         "request": "2.87.0",
         "request-progress": "0.3.1",
@@ -11534,6 +11534,12 @@
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
       "dev": true
     },
+    "moment": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
+      "dev": true
+    },
     "morgan": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
@@ -13112,12 +13118,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-      "dev": true
-    },
-    "progress": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
     },
     "promise": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@types/node": "^10.12.2",
     "all-contributors-cli": "^5.4.1",
     "codelyzer": "~4.5.0",
-    "cypress": "^3.1.1",
+    "cypress": "^3.1.3",
     "express": "^4.16.4",
     "husky": "^1.1.3",
     "jasmine-core": "~3.2.1",


### PR DESCRIPTION
## What:
Due to a malicious dependency `flatmap-stream` within cypress 3.1.1 we had to update package.json to cypress 3.1.2 or higher which has fixed this vulnerability (see https://github.com/cypress-io/cypress/issues/2861).  

Closes #437 
