### PR TITLE
refactor(path aliases): add core, shared and environments path aliases

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,8 +2,8 @@ import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgModule } from '@angular/core';
 
-import { SharedModule } from './shared/shared.module';
-import { CoreModule } from './core/core.module';
+import { SharedModule } from '@shared/shared.module';
+import { CoreModule } from '@core/core.module';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app/app.component';

--- a/src/app/app/app.component.spec.ts
+++ b/src/app/app/app.component.spec.ts
@@ -4,7 +4,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { provideMockStore } from '@ngrx/store/testing';
 
-import { SharedModule } from '../shared/shared.module';
+import { SharedModule } from '@shared/shared.module';
 
 import { AppComponent } from './app.component';
 

--- a/src/app/app/app.component.ts
+++ b/src/app/app/app.component.ts
@@ -3,7 +3,7 @@ import { Component, OnInit } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { Observable } from 'rxjs';
 
-import { environment as env } from '../../environments/environment';
+import { environment as env } from '@environments/environment';
 
 import {
   ActionAuthLogin,
@@ -17,7 +17,7 @@ import {
   selectSettingsLanguage,
   selectEffectiveTheme,
   ActionSettingsChangeLanguage
-} from '../core/core.module';
+} from '@core/core.module';
 
 @Component({
   selector: 'anms-root',

--- a/src/app/core/auth/auth-guard.service.spec.ts
+++ b/src/app/core/auth/auth-guard.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { Store } from '@ngrx/store';
 import { provideMockStore, MockStore } from '@ngrx/store/testing';
 
-import { AppState } from '../core.state';
+import { AppState } from '@core/core.state';
 
 import { AuthGuardService } from './auth-guard.service';
 import { AuthState } from './auth.models';

--- a/src/app/core/auth/auth-guard.service.ts
+++ b/src/app/core/auth/auth-guard.service.ts
@@ -4,7 +4,7 @@ import { Store, select } from '@ngrx/store';
 import { Observable } from 'rxjs';
 
 import { selectIsAuthenticated } from './auth.selectors';
-import { AppState } from '../core.state';
+import { AppState } from '@core/core.state';
 
 @Injectable({
   providedIn: 'root'

--- a/src/app/core/auth/auth.effects.spec.ts
+++ b/src/app/core/auth/auth.effects.spec.ts
@@ -4,7 +4,7 @@ import { Actions, getEffectsMetadata } from '@ngrx/effects';
 import { EMPTY } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 
-import { LocalStorageService } from '../local-storage/local-storage.service';
+import { LocalStorageService } from '@core/local-storage/local-storage.service';
 import { ActionAuthLogin, ActionAuthLogout } from './auth.actions';
 import { AuthEffects, AUTH_KEY } from './auth.effects';
 

--- a/src/app/core/auth/auth.effects.ts
+++ b/src/app/core/auth/auth.effects.ts
@@ -4,7 +4,7 @@ import { Action } from '@ngrx/store';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { tap } from 'rxjs/operators';
 
-import { LocalStorageService } from '../local-storage/local-storage.service';
+import { LocalStorageService } from '@core/local-storage/local-storage.service';
 
 import {
   ActionAuthLogin,

--- a/src/app/core/auth/auth.selectors.ts
+++ b/src/app/core/auth/auth.selectors.ts
@@ -1,6 +1,6 @@
 import { createSelector } from '@ngrx/store';
 
-import { selectAuthState } from '../core.state';
+import { selectAuthState } from '@core/core.state';
 import { AuthState } from './auth.models';
 
 export const selectAuth = createSelector(

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -15,7 +15,7 @@ import { StoreDevtoolsModule } from '@ngrx/store-devtools';
 import { TranslateModule, TranslateLoader } from '@ngx-translate/core';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 
-import { environment } from '../../environments/environment';
+import { environment } from '@environments/environment';
 
 import {
   AppState,

--- a/src/app/core/core.state.ts
+++ b/src/app/core/core.state.ts
@@ -5,7 +5,7 @@ import {
 } from '@ngrx/store';
 import { routerReducer, RouterReducerState } from '@ngrx/router-store';
 
-import { environment } from '../../environments/environment';
+import { environment } from '@environments/environment';
 
 import { initStateFromLocalStorage } from './meta-reducers/init-state-from-local-storage.reducer';
 import { debug } from './meta-reducers/debug.reducer';

--- a/src/app/core/error-handler/app-error-handler.service.ts
+++ b/src/app/core/error-handler/app-error-handler.service.ts
@@ -1,9 +1,9 @@
 import { Injectable, ErrorHandler } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
 
-import { environment } from '../../../environments/environment';
+import { environment } from '@environments/environment';
 
-import { NotificationService } from '../notifications/notification.service';
+import { NotificationService } from '@core/notifications/notification.service';
 
 /** Application-wide error handler that adds a UI notification to the error handling
  * provided by the default Angular ErrorHandler.

--- a/src/app/core/meta-reducers/debug.reducer.ts
+++ b/src/app/core/meta-reducers/debug.reducer.ts
@@ -1,6 +1,6 @@
 import { ActionReducer } from '@ngrx/store';
 
-import { AppState } from '../core.state';
+import { AppState } from '@core/core.state';
 
 export function debug(
   reducer: ActionReducer<AppState>

--- a/src/app/core/meta-reducers/init-state-from-local-storage.reducer.ts
+++ b/src/app/core/meta-reducers/init-state-from-local-storage.reducer.ts
@@ -1,7 +1,7 @@
 import { ActionReducer, INIT, UPDATE } from '@ngrx/store';
 
-import { LocalStorageService } from '../local-storage/local-storage.service';
-import { AppState } from '../core.state';
+import { LocalStorageService } from '@core/local-storage/local-storage.service';
+import { AppState } from '@core/core.state';
 
 export function initStateFromLocalStorage(
   reducer: ActionReducer<AppState>

--- a/src/app/core/settings/settings.effects.spec.ts
+++ b/src/app/core/settings/settings.effects.spec.ts
@@ -11,7 +11,7 @@ import {
   AppState,
   LocalStorageService,
   TitleService
-} from '../core.module';
+} from '@core/core.module';
 
 import { SettingsEffects, SETTINGS_KEY } from './settings.effects';
 import { SettingsState } from './settings.model';

--- a/src/app/core/settings/settings.effects.ts
+++ b/src/app/core/settings/settings.effects.ts
@@ -14,10 +14,10 @@ import {
   filter
 } from 'rxjs/operators';
 
-import { selectSettingsState } from '../core.state';
-import { LocalStorageService } from '../local-storage/local-storage.service';
-import { AnimationsService } from '../animations/animations.service';
-import { TitleService } from '../title/title.service';
+import { selectSettingsState } from '@core/core.state';
+import { LocalStorageService } from '@core/local-storage/local-storage.service';
+import { AnimationsService } from '@core/animations/animations.service';
+import { TitleService } from '@core/title/title.service';
 
 import {
   SettingsActionTypes,

--- a/src/app/core/settings/settings.model.ts
+++ b/src/app/core/settings/settings.model.ts
@@ -1,4 +1,4 @@
-import { AppState } from '../core.module';
+import { AppState } from '@core/core.module';
 
 export const NIGHT_MODE_THEME = 'BLACK-THEME';
 

--- a/src/app/core/settings/settings.selectors.ts
+++ b/src/app/core/settings/settings.selectors.ts
@@ -1,7 +1,7 @@
 import { createSelector } from '@ngrx/store';
 
 import { SettingsState } from './settings.model';
-import { selectSettingsState } from '../core.state';
+import { selectSettingsState } from '@core/core.state';
 
 export const selectSettings = createSelector(
   selectSettingsState,

--- a/src/app/core/title/title.service.ts
+++ b/src/app/core/title/title.service.ts
@@ -4,7 +4,7 @@ import { ActivatedRouteSnapshot } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { filter } from 'rxjs/operators';
 
-import { environment as env } from '../../../environments/environment';
+import { environment as env } from '@environments/environment';
 
 @Injectable({
   providedIn: 'root'

--- a/src/app/features/about/about.module.ts
+++ b/src/app/features/about/about.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
-import { SharedModule } from '../../shared/shared.module';
+import { SharedModule } from '@shared/shared.module';
 
 import { AboutComponent } from './about/about.component';
 import { AboutRoutingModule } from './about-routing.module';

--- a/src/app/features/about/about/about.component.spec.ts
+++ b/src/app/features/about/about/about.component.spec.ts
@@ -2,7 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule } from '@ngx-translate/core';
 
-import { SharedModule } from '../../../shared/shared.module';
+import { SharedModule } from '@shared/shared.module';
 
 import { AboutComponent } from './about.component';
 

--- a/src/app/features/about/about/about.component.ts
+++ b/src/app/features/about/about/about.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
 
-import { ROUTE_ANIMATIONS_ELEMENTS } from '../../../core/core.module';
+import { ROUTE_ANIMATIONS_ELEMENTS } from '@core/core.module';
 
 @Component({
   selector: 'anms-about',

--- a/src/app/features/examples/authenticated/authenticated.component.spec.ts
+++ b/src/app/features/examples/authenticated/authenticated.component.spec.ts
@@ -2,7 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule } from '@ngx-translate/core';
 
-import { SharedModule } from '../../../shared/shared.module';
+import { SharedModule } from '@shared/shared.module';
 
 import { AuthenticatedComponent } from './authenticated.component';
 

--- a/src/app/features/examples/authenticated/authenticated.component.ts
+++ b/src/app/features/examples/authenticated/authenticated.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
 
-import { ROUTE_ANIMATIONS_ELEMENTS } from '../../../core/core.module';
+import { ROUTE_ANIMATIONS_ELEMENTS } from '@core/core.module';
 
 @Component({
   selector: 'anms-authenticated',

--- a/src/app/features/examples/crud/books.effects.spec.ts
+++ b/src/app/features/examples/crud/books.effects.spec.ts
@@ -3,7 +3,7 @@ import { Store } from '@ngrx/store';
 import { EMPTY, of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 
-import { LocalStorageService } from '../../../core/core.module';
+import { LocalStorageService } from '@core/core.module';
 
 import { ActionBooksDeleteOne, ActionBooksUpsertOne } from './books.actions';
 import { BookState } from './books.model';

--- a/src/app/features/examples/crud/books.effects.ts
+++ b/src/app/features/examples/crud/books.effects.ts
@@ -3,7 +3,7 @@ import { Action, select, Store } from '@ngrx/store';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { tap, withLatestFrom } from 'rxjs/operators';
 
-import { LocalStorageService } from '../../../core/core.module';
+import { LocalStorageService } from '@core/core.module';
 
 import { State } from '../examples.state';
 import { BookActionTypes } from './books.actions';

--- a/src/app/features/examples/crud/books.selectors.ts
+++ b/src/app/features/examples/crud/books.selectors.ts
@@ -1,6 +1,6 @@
 import { createSelector } from '@ngrx/store';
 
-import { selectRouterState } from '../../../core/core.module';
+import { selectRouterState } from '@core/core.module';
 import { selectExamples, ExamplesState } from '../examples.state';
 
 import { bookAdapter } from './books.reducer';

--- a/src/app/features/examples/crud/components/crud.component.spec.ts
+++ b/src/app/features/examples/crud/components/crud.component.spec.ts
@@ -5,7 +5,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { Store } from '@ngrx/store';
 import { provideMockStore, MockStore } from '@ngrx/store/testing';
 
-import { SharedModule } from '../../../../shared/shared.module';
+import { SharedModule } from '@shared/shared.module';
 
 import { State } from '../../examples.state';
 import { CrudComponent } from './crud.component';

--- a/src/app/features/examples/crud/components/crud.component.ts
+++ b/src/app/features/examples/crud/components/crud.component.ts
@@ -5,7 +5,7 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { Observable } from 'rxjs';
 
-import { ROUTE_ANIMATIONS_ELEMENTS } from '../../../../core/core.module';
+import { ROUTE_ANIMATIONS_ELEMENTS } from '@core/core.module';
 
 import { State } from '../../examples.state';
 import { Book } from '../books.model';

--- a/src/app/features/examples/examples-routing.module.ts
+++ b/src/app/features/examples/examples-routing.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 
-import { AuthGuardService } from '../../core/core.module';
+import { AuthGuardService } from '@core/core.module';
 
 import { ExamplesComponent } from './examples/examples.component';
 import { ParentComponent } from './theming/parent/parent.component';

--- a/src/app/features/examples/examples.effects.spec.ts
+++ b/src/app/features/examples/examples.effects.spec.ts
@@ -9,7 +9,7 @@ import {
   TitleService,
   SettingsActions,
   ActionSettingsChangeLanguage
-} from '../../core/core.module';
+} from '@core/core.module';
 
 import { ExamplesEffects } from './examples.effects';
 import { State } from './examples.state';

--- a/src/app/features/examples/examples.effects.ts
+++ b/src/app/features/examples/examples.effects.ts
@@ -12,7 +12,7 @@ import {
   AppState,
   selectSettingsLanguage,
   SettingsActionTypes
-} from '../../core/core.module';
+} from '@core/core.module';
 
 @Injectable()
 export class ExamplesEffects {

--- a/src/app/features/examples/examples.module.ts
+++ b/src/app/features/examples/examples.module.ts
@@ -5,8 +5,8 @@ import { EffectsModule } from '@ngrx/effects';
 import { TranslateModule, TranslateLoader } from '@ngx-translate/core';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 
-import { SharedModule } from '../../shared/shared.module';
-import { environment } from '../../../environments/environment';
+import { SharedModule } from '@shared/shared.module';
+import { environment } from '@environments/environment';
 
 import { FEATURE_NAME, reducers } from './examples.state';
 import { ExamplesRoutingModule } from './examples-routing.module';

--- a/src/app/features/examples/examples.state.ts
+++ b/src/app/features/examples/examples.state.ts
@@ -1,6 +1,6 @@
 import { ActionReducerMap, createFeatureSelector } from '@ngrx/store';
 
-import { AppState } from '../../core/core.module';
+import { AppState } from '@core/core.module';
 
 import { todosReducer } from './todos/todos.reducer';
 import { TodosState } from './todos/todos.model';

--- a/src/app/features/examples/examples/examples.component.spec.ts
+++ b/src/app/features/examples/examples/examples.component.spec.ts
@@ -3,7 +3,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { SharedModule } from '../../../shared/shared.module';
+import { SharedModule } from '@shared/shared.module';
 
 import { ExamplesComponent } from './examples.component';
 import { provideMockStore } from '@ngrx/store/testing';

--- a/src/app/features/examples/examples/examples.component.ts
+++ b/src/app/features/examples/examples/examples.component.ts
@@ -2,10 +2,7 @@ import { Store, select } from '@ngrx/store';
 import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { Observable } from 'rxjs';
 
-import {
-  routeAnimations,
-  selectIsAuthenticated
-} from '../../../core/core.module';
+import { routeAnimations, selectIsAuthenticated } from '@core/core.module';
 
 import { State } from '../examples.state';
 

--- a/src/app/features/examples/form/components/form.component.spec.ts
+++ b/src/app/features/examples/form/components/form.component.spec.ts
@@ -2,7 +2,7 @@
 // import { Store } from '@ngrx/store';
 //
 // import { MockStore, TestingModule } from '../../../../testing/utils';
-// import { NotificationService } from '../../../core/core.module';
+// import { NotificationService } from '@core/core.module';
 //
 // import { State } from '../../examples.state';
 // import { FormState } from '../form.model';

--- a/src/app/features/examples/form/components/form.component.ts
+++ b/src/app/features/examples/form/components/form.component.ts
@@ -8,7 +8,7 @@ import { Observable } from 'rxjs';
 import {
   ROUTE_ANIMATIONS_ELEMENTS,
   NotificationService
-} from '../../../../core/core.module';
+} from '@core/core.module';
 
 import { State } from '../../examples.state';
 import { ActionFormUpdate, ActionFormReset } from '../form.actions';

--- a/src/app/features/examples/form/form.effects.spec.ts
+++ b/src/app/features/examples/form/form.effects.spec.ts
@@ -3,7 +3,7 @@ import { Actions, getEffectsMetadata } from '@ngrx/effects';
 import { EMPTY } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 
-import { LocalStorageService } from '../../../core/core.module';
+import { LocalStorageService } from '@core/core.module';
 
 import { ActionFormUpdate } from './form.actions';
 import { FormEffects, FORM_KEY } from './form.effects';

--- a/src/app/features/examples/form/form.effects.ts
+++ b/src/app/features/examples/form/form.effects.ts
@@ -3,7 +3,7 @@ import { Action } from '@ngrx/store';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { tap } from 'rxjs/operators';
 
-import { LocalStorageService } from '../../../core/core.module';
+import { LocalStorageService } from '@core/core.module';
 
 import { ActionFormUpdate, FormActionTypes } from './form.actions';
 

--- a/src/app/features/examples/notifications/components/notifications.component.spec.ts
+++ b/src/app/features/examples/notifications/components/notifications.component.spec.ts
@@ -2,8 +2,8 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule } from '@ngx-translate/core';
 
-import { NotificationService } from '../../../../core/core.module';
-import { SharedModule } from '../../../../shared/shared.module';
+import { NotificationService } from '@core/core.module';
+import { SharedModule } from '@shared/shared.module';
 
 import { NotificationsComponent } from './notifications.component';
 

--- a/src/app/features/examples/notifications/components/notifications.component.ts
+++ b/src/app/features/examples/notifications/components/notifications.component.ts
@@ -3,7 +3,7 @@ import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import {
   ROUTE_ANIMATIONS_ELEMENTS,
   NotificationService
-} from '../../../../core/core.module';
+} from '@core/core.module';
 
 @Component({
   selector: 'anms-notifications',

--- a/src/app/features/examples/stock-market/components/stock-market-container.component.spec.ts
+++ b/src/app/features/examples/stock-market/components/stock-market-container.component.spec.ts
@@ -7,7 +7,7 @@ import { Store } from '@ngrx/store';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { EMPTY } from 'rxjs';
 
-import { SharedModule } from '../../../../shared/shared.module';
+import { SharedModule } from '@shared/shared.module';
 
 import { State } from '../../examples.state';
 import { StockMarketService } from '../stock-market.service';

--- a/src/app/features/examples/stock-market/components/stock-market-container.component.ts
+++ b/src/app/features/examples/stock-market/components/stock-market-container.component.ts
@@ -3,7 +3,7 @@ import { Store, select } from '@ngrx/store';
 import { Observable } from 'rxjs';
 import { take } from 'rxjs/operators';
 
-import { ROUTE_ANIMATIONS_ELEMENTS } from '../../../../core/core.module';
+import { ROUTE_ANIMATIONS_ELEMENTS } from '@core/core.module';
 
 import { selectStockMarket } from '../stock-market.selectors';
 import { ActionStockMarketRetrieve } from '../stock-market.actions';

--- a/src/app/features/examples/stock-market/stock-market.effects.spec.ts
+++ b/src/app/features/examples/stock-market/stock-market.effects.spec.ts
@@ -3,7 +3,7 @@ import { Actions } from '@ngrx/effects';
 import { of, throwError } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 
-import { LocalStorageService } from '../../../core/core.module';
+import { LocalStorageService } from '@core/core.module';
 
 import {
   ActionStockMarketRetrieve,

--- a/src/app/features/examples/stock-market/stock-market.effects.ts
+++ b/src/app/features/examples/stock-market/stock-market.effects.ts
@@ -4,7 +4,7 @@ import { Action } from '@ngrx/store';
 import { asyncScheduler, of } from 'rxjs';
 import { catchError, debounceTime, map, switchMap, tap } from 'rxjs/operators';
 
-import { LocalStorageService } from '../../../core/core.module';
+import { LocalStorageService } from '@core/core.module';
 
 import {
   ActionStockMarketRetrieve,

--- a/src/app/features/examples/theming/child/child.component.spec.ts
+++ b/src/app/features/examples/theming/child/child.component.spec.ts
@@ -2,7 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule } from '@ngx-translate/core';
 
-import { SharedModule } from '../../../../shared/shared.module';
+import { SharedModule } from '@shared/shared.module';
 
 import { ChildComponent } from './child.component';
 

--- a/src/app/features/examples/theming/parent/parent.component.spec.ts
+++ b/src/app/features/examples/theming/parent/parent.component.spec.ts
@@ -2,7 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule } from '@ngx-translate/core';
 
-import { SharedModule } from '../../../../shared/shared.module';
+import { SharedModule } from '@shared/shared.module';
 
 import { ChildComponent } from '../child/child.component';
 import { ParentComponent } from './parent.component';

--- a/src/app/features/examples/theming/parent/parent.component.ts
+++ b/src/app/features/examples/theming/parent/parent.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
 
-import { ROUTE_ANIMATIONS_ELEMENTS } from '../../../../core/core.module';
+import { ROUTE_ANIMATIONS_ELEMENTS } from '@core/core.module';
 
 @Component({
   selector: 'anms-parent',

--- a/src/app/features/examples/todos/components/todos-container.component.spec.ts
+++ b/src/app/features/examples/todos/components/todos-container.component.spec.ts
@@ -3,7 +3,7 @@
 // import { Store } from '@ngrx/store';
 //
 // import { MockStore, TestingModule } from '../../../../testing/utils';
-// import { NotificationService } from '../../../core/core.module';
+// import { NotificationService } from '@core/core.module';
 //
 // import {
 //   ActionTodosFilter,

--- a/src/app/features/examples/todos/components/todos-container.component.ts
+++ b/src/app/features/examples/todos/components/todos-container.component.ts
@@ -8,7 +8,7 @@ import { Observable } from 'rxjs';
 import {
   ROUTE_ANIMATIONS_ELEMENTS,
   NotificationService
-} from '../../../../core/core.module';
+} from '@core/core.module';
 
 import {
   ActionTodosAdd,

--- a/src/app/features/examples/todos/todos.effects.spec.ts
+++ b/src/app/features/examples/todos/todos.effects.spec.ts
@@ -4,7 +4,7 @@ import { Actions, getEffectsMetadata } from '@ngrx/effects';
 import { of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 
-import { LocalStorageService } from '../../../core/core.module';
+import { LocalStorageService } from '@core/core.module';
 
 import { State } from '../examples.state';
 import { ActionTodosToggle } from './todos.actions';

--- a/src/app/features/examples/todos/todos.effects.ts
+++ b/src/app/features/examples/todos/todos.effects.ts
@@ -3,7 +3,7 @@ import { Action, select, Store } from '@ngrx/store';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { tap, withLatestFrom } from 'rxjs/operators';
 
-import { LocalStorageService } from '../../../core/core.module';
+import { LocalStorageService } from '@core/core.module';
 
 import { State } from '../examples.state';
 import { TodosActionTypes } from './todos.actions';

--- a/src/app/features/feature-list/feature-list.module.ts
+++ b/src/app/features/feature-list/feature-list.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
-import { SharedModule } from '../../shared/shared.module';
+import { SharedModule } from '@shared/shared.module';
 
 import { FeatureListComponent } from './feature-list/feature-list.component';
 import { FeatureListRoutingModule } from './feature-list-routing.module';

--- a/src/app/features/feature-list/feature-list/feature-list.component.spec.ts
+++ b/src/app/features/feature-list/feature-list/feature-list.component.spec.ts
@@ -2,7 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule } from '@ngx-translate/core';
 
-import { SharedModule } from '../../../shared/shared.module';
+import { SharedModule } from '@shared/shared.module';
 
 import { FeatureListComponent } from './feature-list.component';
 

--- a/src/app/features/feature-list/feature-list/feature-list.component.ts
+++ b/src/app/features/feature-list/feature-list/feature-list.component.ts
@@ -1,8 +1,8 @@
 import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
 
-import { ROUTE_ANIMATIONS_ELEMENTS } from '../../../core/core.module';
+import { ROUTE_ANIMATIONS_ELEMENTS } from '@core/core.module';
 
-import { Feature, features } from '../feature-list.data';
+import { Feature, features } from './feature-list.data';
 
 @Component({
   selector: 'anms-feature-list',

--- a/src/app/features/feature-list/feature-list/feature-list.data.ts
+++ b/src/app/features/feature-list/feature-list/feature-list.data.ts
@@ -1,4 +1,4 @@
-import { environment as env } from '../../../environments/environment';
+import { environment as env } from '@environments/environment';
 
 export interface Feature {
   name: string;

--- a/src/app/features/settings/settings.module.ts
+++ b/src/app/features/settings/settings.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
-import { SharedModule } from '../../shared/shared.module';
+import { SharedModule } from '@shared/shared.module';
 
 import { SettingsRoutingModule } from './settings-routing.module';
 import { SettingsContainerComponent } from './settings/settings-container.component';

--- a/src/app/features/settings/settings/settings-container.component.spec.ts
+++ b/src/app/features/settings/settings/settings-container.component.spec.ts
@@ -5,7 +5,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Store } from '@ngrx/store';
 import { provideMockStore, MockStore } from '@ngrx/store/testing';
 
-import { SharedModule } from '../../../shared/shared.module';
+import { SharedModule } from '@shared/shared.module';
 
 import { SettingsContainerComponent } from './settings-container.component';
 import {
@@ -14,7 +14,7 @@ import {
   ActionSettingsChangeAutoNightMode,
   ActionSettingsChangeTheme,
   ActionSettingsChangeStickyHeader
-} from '../../../core/settings/settings.actions';
+} from '@core/settings/settings.actions';
 import { TranslateModule } from '@ngx-translate/core';
 
 describe('SettingsComponent', () => {

--- a/src/app/features/settings/settings/settings-container.component.ts
+++ b/src/app/features/settings/settings/settings-container.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { Observable } from 'rxjs';
 
-import { ROUTE_ANIMATIONS_ELEMENTS } from '../../../core/core.module';
+import { ROUTE_ANIMATIONS_ELEMENTS } from '@core/core.module';
 
 import {
   ActionSettingsChangeAnimationsElements,
@@ -11,9 +11,9 @@ import {
   ActionSettingsChangeLanguage,
   ActionSettingsChangeTheme,
   ActionSettingsChangeStickyHeader
-} from '../../../core/settings/settings.actions';
-import { SettingsState, State } from '../../../core/settings/settings.model';
-import { selectSettings } from '../../../core/settings/settings.selectors';
+} from '@core/settings/settings.actions';
+import { SettingsState, State } from '@core/settings/settings.model';
+import { selectSettings } from '@core/settings/settings.selectors';
 
 @Component({
   selector: 'anms-settings',

--- a/src/app/shared/big-input/big-input-action/big-input-action.component.spec.ts
+++ b/src/app/shared/big-input/big-input-action/big-input-action.component.spec.ts
@@ -3,7 +3,7 @@ import { By } from '@angular/platform-browser';
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { SharedModule } from '../../shared.module';
+import { SharedModule } from '@shared/shared.module';
 
 @Component({
   selector: 'host-for-test',

--- a/src/app/shared/big-input/big-input/big-input.component.spec.ts
+++ b/src/app/shared/big-input/big-input/big-input.component.spec.ts
@@ -2,7 +2,7 @@ import { Component, DebugElement } from '@angular/core';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { SharedModule } from '../../shared.module';
+import { SharedModule } from '@shared/shared.module';
 
 @Component({
   selector: 'host-for-test',

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
 import { AppModule } from './app/app.module';
-import { environment } from './environments/environment';
+import { environment } from '@environments/environment';
 
 if (environment.production) {
   enableProdMode();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,11 @@
   "compileOnSave": false,
   "compilerOptions": {
     "baseUrl": "./src",
+    "paths": {
+      "@shared/*": ["app/shared/*"],
+      "@core/*": ["app/core/*"],
+      "@environments/*": ["environments/*"]
+    },
     "outDir": "./dist/out-tsc",
     "sourceMap": true,
     "declaration": false,


### PR DESCRIPTION
Updated the root tsconfig.json with 3 path aliases (shared, core and environments). Also updated several import paths to use said aliases as this makes refactoring the project structure easier.