### PR TITLE
fix(change-hours): run change hours interval outside of angular zone

### DIFF
--- a/projects/angular-ngrx-material-starter/e2e/protractor.conf.js
+++ b/projects/angular-ngrx-material-starter/e2e/protractor.conf.js
@@ -9,7 +9,7 @@ const { SpecReporter } = require('jasmine-spec-reporter');
  */
 exports.config = {
   allScriptsTimeout: 11000,
-  specs: ['./src/setup.ts', './src/**/*.e2e-spec.ts'],
+  specs: ['./src/**/*.e2e-spec.ts'],
   capabilities: {
     browserName: 'chrome',
     chromeOptions: {

--- a/projects/angular-ngrx-material-starter/e2e/src/setup.ts
+++ b/projects/angular-ngrx-material-starter/e2e/src/setup.ts
@@ -1,3 +1,0 @@
-import { browser } from 'protractor';
-
-browser.waitForAngularEnabled(false);

--- a/projects/angular-ngrx-material-starter/src/app/core/settings/settings.effects.spec.ts
+++ b/projects/angular-ngrx-material-starter/src/app/core/settings/settings.effects.spec.ts
@@ -5,6 +5,7 @@ import { Actions, getEffectsMetadata } from '@ngrx/effects';
 import { TestScheduler } from 'rxjs/testing';
 import { Store } from '@ngrx/store';
 import { of } from 'rxjs';
+import { NgZone } from '@angular/core';
 
 import {
   AnimationsService,
@@ -29,6 +30,7 @@ describe('SettingsEffects', () => {
   let animationsService: jasmine.SpyObj<AnimationsService>;
   let translateService: jasmine.SpyObj<TranslateService>;
   let store: jasmine.SpyObj<Store<AppState>>;
+  let ngZone: jasmine.SpyObj<NgZone>;
 
   beforeEach(() => {
     router = {
@@ -51,6 +53,8 @@ describe('SettingsEffects', () => {
     ]);
     translateService = jasmine.createSpyObj('TranslateService', ['use']);
     store = jasmine.createSpyObj('store', ['pipe']);
+    ngZone = jasmine.createSpyObj('mockNgZone', ['run', 'runOutsideAngular']);
+    ngZone.run.and.callFake(fn => fn());
   });
 
   it('should call methods on LocalStorageService for PERSIST action', () => {
@@ -80,7 +84,8 @@ describe('SettingsEffects', () => {
         localStorageService,
         titleService,
         animationsService,
-        translateService
+        translateService,
+        ngZone
       );
 
       effect.persistSettings.subscribe(() => {


### PR DESCRIPTION
<!--

Hi, thanks for taking the time to submit this Pull Request, it is really appreciated!

Before submitting the Pull Request make sure you:

* are familiar with and follow the Code of Conduct for
  this project: CODE_OF_CONDUCT.md

* the commit message follows our guidelines: CONTRIBUTING.md#commit-message-guidelines

Feel free to add yourself as a contributor via `npm run contributors:add` and don't forget to run 
`npm run contributors:generate` after this. For example:

$ npm run contributors:add username code,test,translation
$ npm run contributors:generate

-->

## What: Updated change hours effect interval to run outside of Angular zone. This should fix the testability not stabilizing issue without affecting the nature of the effect (to adjust the theme upon app load based on current time).
<!-- What changes are being made, why are these changes necessary? -->
Closes #511 
<!--  To automatically close the corresponding issue use: Closes #<issue-number, e.g. Closes #47 -->
Issue number: #511 
