### PR TITLE
docs(features): update bootstrap doc. link

### DIFF
--- a/projects/angular-ngrx-material-starter/src/app/features/feature-list/feature-list.data.ts
+++ b/projects/angular-ngrx-material-starter/src/app/features/feature-list/feature-list.data.ts
@@ -54,7 +54,8 @@ export const features: Feature[] = [
     version: env.versions.bootstrap,
     description: 'anms.features.bootstrap',
     github: 'https://github.com/twbs/bootstrap',
-    documentation: 'https://getbootstrap.com/docs/4.4/getting-started/introduction/',
+    documentation:
+      'https://getbootstrap.com/docs/4.4/getting-started/introduction/',
     medium:
       'https://medium.com/@tomastrajan/how-to-build-responsive-layouts-with-bootstrap-4-and-angular-6-cfbb108d797b'
   },

--- a/projects/angular-ngrx-material-starter/src/app/features/feature-list/feature-list.data.ts
+++ b/projects/angular-ngrx-material-starter/src/app/features/feature-list/feature-list.data.ts
@@ -54,7 +54,7 @@ export const features: Feature[] = [
     version: env.versions.bootstrap,
     description: 'anms.features.bootstrap',
     github: 'https://github.com/twbs/bootstrap',
-    documentation: 'https://getbootstrap.com/docs/4.0/layout/grid/',
+    documentation: 'https://getbootstrap.com/docs/4.4/getting-started/introduction/',
     medium:
       'https://medium.com/@tomastrajan/how-to-build-responsive-layouts-with-bootstrap-4-and-angular-6-cfbb108d797b'
   },


### PR DESCRIPTION
## What:

Update the Bootstrap documentation link to (4.0 -> 4.4) better match the version package dependencies (`"bootstrap": "^4.4.1",`) & documentation path from `../layout/grid/` to `../getting-started/introduction/`

Issue number: N/A
