### PR TITLE
fix: set correct, relative, src paths for assets

### DIFF
--- a/projects/angular-ngrx-material-starter/src/app/app/app.component.ts
+++ b/projects/angular-ngrx-material-starter/src/app/app/app.component.ts
@@ -31,7 +31,7 @@ export class AppComponent implements OnInit {
   envName = env.envName;
   version = env.versions.app;
   year = new Date().getFullYear();
-  logo = '/assets/logo.png';
+  logo = 'assets/logo.png';
   languages = ['en', 'de', 'sk', 'fr', 'es', 'pt-br', 'zh-cn', 'he'];
   navigation = [
     { link: 'about', label: 'anms.menu.about' },

--- a/projects/angular-ngrx-material-starter/src/app/features/about/about/about.component.ts
+++ b/projects/angular-ngrx-material-starter/src/app/features/about/about/about.component.ts
@@ -10,7 +10,7 @@ import { ROUTE_ANIMATIONS_ELEMENTS } from '../../../core/core.module';
 })
 export class AboutComponent implements OnInit {
   routeAnimationsElements = ROUTE_ANIMATIONS_ELEMENTS;
-  releaseButler = '/assets/release-butler.png';
+  releaseButler = 'assets/release-butler.png';
 
   constructor() {}
 


### PR DESCRIPTION
## What:
Set relative src path for assets in order to work properly on github pages.

This fixes the following:

![faulty_assets_path](https://user-images.githubusercontent.com/21139323/121374377-232a5980-c940-11eb-9a8f-4fc101f84e0f.png)

Issue number: N/A
