### PR TITLE
fix: base href

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "watch": "ng test --configuration=test --browsers ChromeHeadless --watch --reporters dots",
     "e2e": "ng e2e",
     "e2e:ci": "ng e2e",
-    "ci": "npm run format:test && npm run lint && ng test --configuration=test --browsers ChromeTravisCi --code-coverage && npm run build:prod -- --deploy-url /angular-ngrx-material-starter/ --base-href /angular-ngrx-material-starter",
+    "ci": "npm run format:test && npm run lint && ng test --configuration=test --browsers ChromeTravisCi --code-coverage && npm run build:prod -- --deploy-url /angular-ngrx-material-starter/ --base-href /angular-ngrx-material-starter/",
     "format:write": "prettier projects/**/*.{ts,json,md,scss} --write",
     "format:test": "prettier projects/**/*.{ts,json,md,scss} --list-different",
     "release": "standard-version && git push --follow-tags origin master",


### PR DESCRIPTION
## What:
fix: set base href with trailing slash for production build

- in order to use relative path urls, the base-href tag has to be set with a trailing slash, e.g. `<base href="some_path/" />`
- for more information see [Stackoverflow Answer](https://stackoverflow.com/a/26043021/13226740) 
- tldr see screenshot:
 
![base_href](https://user-images.githubusercontent.com/21139323/121501995-05accc80-c9e0-11eb-84dc-fe32b7629575.png)


## Issue number: 
see discussion in previous [PR](https://github.com/tomastrajan/angular-ngrx-material-starter/pull/551) 

## Wat is fixed:
assets path urls, such as the logo, the favicon or images on "about" page

## What was successfully testet as well:
i18n files, that are also delivered from "assets" folder

## More:
the hash-routing was not the problem, but it isn't needed anymore to make the app work on GH pages --> I could do another PR to change this, if you like