### PR TITLE
feat: remove hash location opt in

### DIFF
--- a/projects/angular-ngrx-material-starter/src/app/app-routing.module.ts
+++ b/projects/angular-ngrx-material-starter/src/app/app-routing.module.ts
@@ -40,10 +40,8 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  // useHash supports github.io demo page, remove in your app
   imports: [
     RouterModule.forRoot(routes, {
-      useHash: true,
       scrollPositionRestoration: 'enabled',
       preloadingStrategy: PreloadAllModules,
       relativeLinkResolution: 'legacy'


### PR DESCRIPTION
## What:
Remove hash location opt in.
- hash location strategy is no longer necessary to work with GiiHub Pages
- see test deployment from forked repo: https://tino-tg.github.io/angular-ngrx-material-starter - of course i will remove the deployment after the PR is merged 
- for further information check out the [docs](https://angular.io/guide/router#locationstrategy-and-browser-url-styles)

Issue number: see diescussion in [previous PR](https://github.com/tomastrajan/angular-ngrx-material-starter/pull/552)
